### PR TITLE
Make profile command output prettier (ugly code version)

### DIFF
--- a/PerformanceCalculator/Profile/UserPlayInfo.cs
+++ b/PerformanceCalculator/Profile/UserPlayInfo.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Game.Beatmaps;
 
 namespace PerformanceCalculator.Profile
@@ -12,16 +13,17 @@ namespace PerformanceCalculator.Profile
     {
         public double LocalPP;
         public double LivePP;
-        public double AimPP;
-        public double TapPP;
-        public double AccPP;
+
+        public Dictionary<string, double> MapCategoryAttribs;
 
         public double PlayAccuracy;
         public int PlayMaxCombo;
         public int BeatmapMaxCombo;
         public int MissCount;
+        public int Position;
 
         public BeatmapInfo Beatmap;
+        public string MapName;
 
         public string Mods;
     }

--- a/PerformanceCalculator/README.md
+++ b/PerformanceCalculator/README.md
@@ -100,35 +100,36 @@ Arguments:
   api key                    API Key, which you can get from here: https://old.ppy.sh/p/api
 
 Options:
-  -?|-h|--help               Show help information
-  -r|--ruleset:<ruleset-id>  The ruleset to compute the profile for. 0 - osu!, 1 - osu!taiko, 2 - osu!catch, 3 - osu!mania. Defaults to osu!.
-  -o|--output <file.txt>     Output results to text file.
+  -?|-h|--help                   Show help information
+  -r|--ruleset <ruleset-id>      The ruleset to compute the profile for. 0 -
+                                 osu!, 1 - osu!taiko, 2 - osu!catch, 3 -
+                                 osu!mania. Defaults to osu!.
+  -c|--columns <attribute_name>  Extra columns to display from beatmap category
+                                 attribs, for example 'Tap Rhythm pp'. Multiple
+                                 can be added at once -c col1 -c col2
+  -s|--sort <attribute_name>     What column to sort by (defaults to pp of the
+                                 play)
+  -o|--output <file.txt>         Output results to text file.
 ```
 
 Computes the performance of a user profile's performance. Takes 100 top plays of a user and recalculates and reorders them in order of the performance calculator's calculated performance.
 
 ```
-User:     peppy
-Live PP:  765.9 (including 100.1pp from playcount)
-Local PP: 766.7
+User:     chocomint
+Live PP:  14937,5 (including 305,6pp from playcount)
+Local PP: 15310,0 (+372,5)
 
-╔═════════════════════════════════════════════════════════════════════════════════════════════════╤═══════╤════════╤═════════╤═══════════════╗
-║beatmap                                                                                          │live pp│local pp│pp change│position change║
-╟─────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼────────┼─────────┼───────────────╢
-║22423 - Lix - Tori no Uta -Ethereal House Mix- (James) [Hard]                                    │   64.1│    64.3│      0.2│       -       ║
-╟─────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼────────┼─────────┼───────────────╢
-║258467 - Global Deejays - The Sound of San Francisco (Sey) [San Francisco]                       │   49.9│    50.2│      0.2│       -       ║
-╟─────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼────────┼─────────┼───────────────╢
-║266885 - Owl City - When Can I See You Again? (Aleks719) [Next year!]                            │   48.9│    49.1│      0.1│       -       ║
-╟─────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼────────┼─────────┼───────────────╢
-║197337 - Sakamoto Maaya - Platinum (TV Size) (Flask) [Insane]                                    │   45.7│    45.8│      0.1│       -       ║
-╟─────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼────────┼─────────┼───────────────╢
-║119488 - Nakamura Mamechiyo - Kare Kano Kanon (mjw5150) [Hard]                                   │   42.2│    42.3│      0.1│       -       ║
-╟─────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼────────┼─────────┼───────────────╢
-║417911 - yanaginagi - Tokohana (TV Size) (Sharlo) [Fycho's Hard]                                 │   39.8│    39.6│     -0.2│       -       ║
-╟─────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼────────┼─────────┼───────────────╢
-║80 - Scatman John - Scatman (Extor) [Insane]                                                     │   36.1│    37.6│      1.5│      +1       ║
-╟─────────────────────────────────────────────────────────────────────────────────────────────────┼───────┼────────┼─────────┼───────────────╢
+╔═══╤════════════════════════════════════════════════════════════════════════════════════════════════════════╤════════╤═══════╤════════╤════╤═════════╤════════╤═════════╤═══════════════╗
+║ # │beatmap                                                                                                 │  mods  │live pp│  acc   │miss│  combo  │local pp│pp change│position change║
+╟───┼────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────┼───────┼────────┼────┼─────────┼────────┼─────────┼───────────────╢
+║1  │ 1031991 - ...s Dead Decadence - Yomi yori Kikoyu, Koukoku no Tou to Honoo no Shoujo. (DoKito) [Kyouaku]│      HD│  712,1│ 99,07 %│   4│2936/4353│   948,8│    236,8│      +19      ║
+╟───┼────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────┼───────┼────────┼────┼─────────┼────────┼─────────┼───────────────╢
+║2  │ 129891 - xi - FREEDOM DiVE (Nakagawa-Kanon) [FOUR DIMENSIONS]                                          │   HR|HD│  894,4│ 99,83 %│   0│2385/2385│   850,4│    -44,0│      -1       ║
+╟───┼────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────┼───────┼────────┼────┼─────────┼────────┼─────────┼───────────────╢
+║3  │ 1432943 - ...oshi o Kakeru Adventure ~ we are forever friends! ~ [Long ver.] (Battle) [Imagined Voyage]│   HR|HD│  764,3│ 99,41 %│   0│2336/2640│   833,4│     69,1│      +4       ║
+╟───┼────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────┼───────┼────────┼────┼─────────┼────────┼─────────┼───────────────╢
+║4  │ 1869619 - Umeboshi Chazuke - Bison Charge (Nao Tomori) [Extreme]                                       │      HD│  725,5│ 99,70 %│   0│  886/886│   829,9│    104,4│      +10      ║
+╟───┼────────────────────────────────────────────────────────────────────────────────────────────────────────┼────────┼───────┼────────┼────┼─────────┼────────┼─────────┼───────────────╢
 ...
 ```
 


### PR DESCRIPTION
Backporting -s and -c args from the localscores command to the profile command, and apply the few aesthetics enhancements ive done to the local scores command too. The code is starting to get pretty ugly, next PR will fix it and share the grid code instead of duplicating it everywhere.

here is what it looks like:
![image](https://user-images.githubusercontent.com/25670169/102642415-ebdfaa80-415d-11eb-889e-b9be30b382aa.png)

